### PR TITLE
Upgrade to python3 & implement requirements.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ After generating and signing the _SAMLResponse_'s _assertion_, shimit will call 
 For installing the required modules, run the following command:
 
 ```
-python -m pip install boto3 botocore defusedxml enum python_dateutil lxml signxml
+pip install -r requirements.txt
 ```
 ### AWS cli ###
 Needs to be installed in order to use the credentials obtained.

--- a/aws.py
+++ b/aws.py
@@ -1,3 +1,4 @@
+from builtins import str
 import os, botocore, boto3, subprocess
 import lxml.etree as etree
 from base64 import b64encode, b64decode

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+awscli==1.16.33
+boto3==1.6.1
+botocore==1.9.1
+defusedxml==0.5.0
+enum34==1.1.6
+lxml==4.1.1
+python-dateutil==2.7.0
+signxml==2.5.2
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 awscli==1.16.33
 boto3==1.6.1
-botocore==1.9.1
+botocore==1.12.23
 defusedxml==0.5.0
 enum34==1.1.6
 lxml==4.1.1

--- a/service_provider.py
+++ b/service_provider.py
@@ -1,8 +1,10 @@
+from builtins import str
+from builtins import object
 import dateutil.parser
 from datetime import datetime, timedelta
 from signxml import XMLSignatureProcessor
 
-class SP():
+class SP(object):
     ''' Abstract class that describes a Service Provider.'''
     
     def __init__(self):

--- a/shimit.py
+++ b/shimit.py
@@ -1,4 +1,5 @@
-# coding: utf-8
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 '''
 Main module to perform a Golden SAML attack.
 

--- a/shimit.py
+++ b/shimit.py
@@ -9,6 +9,7 @@ Execution flow:
     - Use the SAMLResponse to open a session with the SP
     - Apply the session for the user to use
 '''
+from __future__ import print_function
 
 # Imports
 import argparse
@@ -156,7 +157,7 @@ def main():
 
     # Check if the user provided file to load from
     if args.load_file:
-        print "[+] Loading SAMLResponse from file..."
+        print("[+] Loading SAMLResponse from file...")
         saved_response = open(args.load_file, "r").read()
         arn, role_name = AWS.load(saved_response)
         aws_session_token = AWS.assume_role(
@@ -174,7 +175,7 @@ def main():
     session_expiration = AWS.gen_timestamp(base_time=args.time, minutes=int(args.session_validity))
 
     # Create the assertion
-    print "[+] Creating the assertion"
+    print("[+] Creating the assertion")
     root = AWS.create_assertion(
         time,
         args.idp,
@@ -187,7 +188,7 @@ def main():
         args.arn)
 
     # Sign the assertion
-    print "[+] Signing the assertion with the private key provided"
+    print("[+] Signing the assertion with the private key provided")
     signed_root = AWS.sign_assertion(root, args.key, args.cert)
 
     # Insert signed assertion to saml response
@@ -203,21 +204,21 @@ def main():
 
     # Check if the user provided file to export to
     if args.out_file:
-        print "[+] Writing the SAMLResponse to file: %s" % args.out_file
+        print("[+] Writing the SAMLResponse to file: %s" % args.out_file)
         with open(args.out_file, "w") as out_file:
             out_file.write(encoded_response)        
         # Exit
         return
 
     # Assume role and get session token
-    print "[+] Calling AssumeRoleWithSAML API"
+    print("[+] Calling AssumeRoleWithSAML API")
     aws_session_token = AWS.assume_role(
         AWS.TEMPLATES['role_arn'].format(arn=args.arn, role=args.roles[0]),
         AWS.TEMPLATES['principal_arn'].format(arn=args.arn),
         encoded_response)
 
     # Open shell with the session
-    print "[+] Opening a shell"
+    print("[+] Opening a shell")
     AWS.apply_cli_session(aws_session_token["Credentials"], args.region)
 
 if __name__ == "__main__":


### PR DESCRIPTION
I needed this for a penetration test and in its current implementation does not work. In fact, it broke my python2 installation because `enum` package is not supported by python2.7 anymore, and has been deprecated. I did some extensive work to futurize this because well... yeah I needed it.

So, quick summary of what I did.

1. Futurized all packages to python3
2. Moved up packages to latest implementation
3. Implemented requirements.txt according to the `pypi` documentation
4. Refactored all py2 code to python3
5. Excised the cancer that is enum in place of the now supported enum34

This code is largely untested, although I was able to run several commands successfully and generate a valid (forged) SAML Response out of it. Please test and update this code for the sake of your users. It's an awesome tool. Cheers :clinking_glasses: 